### PR TITLE
make the API endpoint relocatable

### DIFF
--- a/internal/application/create.go
+++ b/internal/application/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	createEndpoint = "/application"
+	createEndpoint = "application"
 )
 
 type createCommand struct {

--- a/internal/application/delete.go
+++ b/internal/application/delete.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	deleteEndpoint = "/application/%d"
+	deleteEndpoint = "application/%d"
 )
 
 type deleteCommand struct {

--- a/internal/application/list.go
+++ b/internal/application/list.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	listEndpoint = "/application"
+	listEndpoint = "application"
 )
 
 type listCommand struct {

--- a/internal/application/show.go
+++ b/internal/application/show.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	showEndpoint = "/application/%d"
+	showEndpoint = "application/%d"
 )
 
 type showCommand struct {

--- a/internal/application/update.go
+++ b/internal/application/update.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	updateEndpoint = "/application/%d"
+	updateEndpoint = "application/%d"
 )
 
 type updateCommand struct {


### PR DESCRIPTION
This is necessary when the server is running behind a reverse proxy and the API endpoint does not reside in the server root. Before this patch, the directory element of the `--url=` value was ignored.